### PR TITLE
Restructure definitions

### DIFF
--- a/Definitions.md
+++ b/Definitions.md
@@ -25,7 +25,7 @@
 The *physical* interpretation of a discrete, numeric, finite dimension. Generally represented with a 1D variable that is strictly monotonic and has the same name as the axis it represents. An axis must have *physical* units.
 
 ### *dimension*
-An independent extent of a domain. A domain has N dimensions where N is the minimum number of coordinates needed to identify any particular point within the domain. The length of a discrete, numeric, finite dimension establishes the number of indexable locations along that dimension.
+An independent extent of a domain. A domain has $N$ dimensions where $N$ is the minimum number of coordinates needed to identify any particular point within the domain. The length of a discrete, numeric, finite dimension establishes the number of indexable locations along that dimension.
 
 ### *domain*
 A set of discrete locations in abstract space. A domain, or any location within a domain, may be described by multiple variables, but any given variable has only one domain. A domain has zero or more dimensions. The component dimensions of a domain need not be numeric, but when they are, the domain may be thought of as situated in a coordinate space. If a domain's dimensions are all axes, then that domain is situated in a *physical* space.
@@ -67,17 +67,17 @@ Examples:
 * *sample* intensities measured by a *physical* sensor
     * photon count
     * [Hounsfield unit](https://en.wikipedia.org/wiki/Hounsfield_scale)
-* distances / areas / volumes / times measured in *images* in *physical* units (um, mm, seconds)
-    * "the area of segment A is 12 mm^2"
-    * "mitosis begins at time = 3.2s"
+* distances / areas / volumes / times measured in *images* in *physical* units ($\mu m$, $mm$, seconds)
+    * "the area of segment $A$ is $12 mm^2$"
+    * "mitosis begins at time = $3.2 s$"
 
 Non-examples:
 * *sample* intensities not derived from sensors
     * segmentation id
     * the output of a deep neural network model
 * distances / areas / volumes / times described by *sample* / *array* indexes
-    * "the area of segment B is 85 pixels"
-    * "mitosis begins at frame 51"
+    * "the area of segment $B$ is $85$ pixels"
+    * "mitosis begins at frame $51$"
 
 ### *pixel*
 A single *sample* of a two-dimensional *image*.
@@ -97,7 +97,7 @@ Related terms: *downsampling*, *resolution*
 ### *resolution*
 
 1. The level of detail in an *image*. A high *resolution* *image* will have more *samples* than a low *resolution* *image* for the same *field of view*. 
-2. The total number of *samples* in each dimension of an *image*. For example, a 2-dimensional *image* with 1500 *pixels* along the x dimension and 1000 *pixels* along the y dimension could be said to have a *resolution* of 1500 x 1000 (the colloquial convention is to express the dimensions in x, y, z order).
+2. The total number of *samples* in each dimension of an *image*. For example, a 2-dimensional *image* with $1500$ *pixels* along the x dimension and $1000$ *pixels* along the y dimension could be said to have a *resolution* of $1500 \times 1000$ (the colloquial convention is to express the dimensions in x, y, z order).
 3. The set of *physical* (usually spatial) sampling intervals for an *image*. In other words, the distance between *samples*. Usually expressed separately for each dimension, e.g. millimeters per *pixel* in x. (Note: The sampling *interval* is the reciprocal of the sampling *rate*.)
 
 *Resolution* should be considered synonymous with "spatial resolution" unless otherwise specified.

--- a/Definitions.md
+++ b/Definitions.md
@@ -1,66 +1,66 @@
 # Definitions
 
-- ["array"](#array)                                                                                                                                                                                                
-- ["downsampling"](#downsampling)
-- ["field of view"](#field-of-view)
-- ["filtering"](#filtering)
-- ["group"](#group)
-- ["hierarchy"](#hierarchy)
-- ["image"](#image)
-- ["interpolation"](#interpolation)
-- ["origin"](#origin)
-- ["physical"](#physical)
-- ["pixel"](#pixel)
-- ["resampling"](#resampling)
-- ["resolution"](#resolution)
-- ["sample"](#sample)
-- ["voxel"](#voxel)
+- [*array*](#array)
+- [*downsampling*](#downsampling)
+- [*field of view*](#field-of-view)
+- [*filtering*](#filtering)
+- [*group*](#group)
+- [*hierarchy*](#hierarchy)
+- [*image*](#image)
+- [*interpolation*](#interpolation)
+- [*origin*](#origin)
+- [*physical*](#physical)
+- [*pixel*](#pixel)
+- [*resampling*](#resampling)
+- [*resolution*](#resolution)
+- [*sample*](#sample)
+- [*voxel*](#voxel)
 
 
-### "array" 
+### *array*
 1. An n-dimensional collection of discrete samples whose domain is a regular discrete (integer) grid.
 2. A node in a hierarchy that contains a data structure of the type described in (1). Array nodes cannot have child nodes.
 
-### "axis"
+### *axis*
 The physical interpretation of a discrete, numeric, finite dimension. Generally represented with a 1D variable that is strictly monotonic and has the same name as the axis it represents. An axis must have physical units.
 
-### "dimension"
+### *dimension*
 An independent extent of a domain. A domain has N dimensions where N is the minimum number of coordinates needed to identify any particular point within the domain. The length of a discrete, numeric, finite dimension establishes the number of indexable locations along that dimension.
 
-### "domain"
+### *domain*
 A set of discrete locations in abstract space. A domain, or any location within a domain, may be described by multiple variables, but any given variable has only one domain. A domain has zero or more dimensions. The component dimensions of a domain need not be numeric, but when they are, the domain may be thought of as situated in a coordinate space. If a domain's dimensions are all axes, then that domain is situated in a physical space.
 
-### "downsampling"
+### *downsampling*
 The act of resampling an image to a lower resolution, often by an integer factor.
 
-### "field of view"
+### *field of view*
 The physical extent of the observed space. In microscopy, FOV may be expressed as the diameter of the circular view seen through the eyepiece. In scientific bioimaging, FOV is typically expressed as linear measurements of the horizontal, vertical, and/or diagonal space captured by the digital sensor.   
 
-### "filtering"
+### *filtering*
 1. Usually referes to a convolution operation (a local, linear operation on the intensity values of an image).
 2. Any operation that modifies the intensity values of an image.
 
-### "group"
+### *group*
 A node in a hierarchy that can have child nodes, and can contain metadata, but cannot contain array data.
 
-### "hierarchy"
+### *hierarchy*
 A collection of groups and arrays, connected in a tree-like structure.
 
-### "image"
+### *image*
 A set of numbers intended to be displayed on a screen. Ancillary data structures may be required to display or interpret an image (such as a lookup table), but these are not part of the image itself. An image is often, but not necessarily, acquired by a sensor situated within an optical system. Images can be represented in compact forms, for example as a compressed sequence of bytes or as a discrete function over a finite domain, but these are not canonical uses of the word “image”, and the word “image” by itself should refer only to arrays and array-like data structures.
 
-### "interpolation"
+### *interpolation*
 A process that, given an image, produces new samples at points in the domain not on the discrete image grid.
 
 The most common methods for interpolation are "nearest-neighbor", "bi-/tri-/n-linear", "cubic", "windowed sinc".
 
-### "origin"
+### *origin*
 1. Of an array: the point in the discrete domain with the minimum index (usually zero) for all dimensions.
 2. Of an image: the point in the physical domain corresponding to the array origin.
 
-The term "offset" is sometimes used to refer to the "origin".
+The term "offset" is sometimes used to refer to the *origin*.
 
-### "physical"
+### *physical*
 Relating to quantities or measurements of the physical world.
 
 Examples:
@@ -79,34 +79,34 @@ Non-examples:
     * "the area of segment B is 85 pixels"
     * "mitosis begins at frame 51"
 
-### "pixel" 
+### *pixel*
 A single sample of a two-dimensional image.
 
-Often used interchangeably with "sample".
+Often used interchangeably with *sample*.
 
-Related terms: "sample", "voxel"
+Related terms: *sample*, *voxel*
 
-### "resampling"
+### *resampling*
 A process that generates a new array representing an image at a new resolution. 
 
 The new resolution is often an integer multiple of the original image resolution, but need not be. Resampling methods often
 consist of filtering and interpolation steps.
 
-Related terms: "downsampling", "resolution"
+Related terms: *downsampling*, *resolution*
 
-### "resolution"
+### *resolution*
 
 1. The level of detail in an image. A high resolution image will have more samples than a low resolution image for the same field of view. 
 2. The total number of samples in each dimension of an image. For example, a 2-dimensional image with 1500 pixels along the x dimension and 1000 pixels along the y dimension could be said to have a resolution of 1500 x 1000 (the colloquial convention is to express the dimensions in x, y, z order).
 3. The set of physical (usually spatial) sampling intervals for an image. In other words, the distance between samples. Usually expressed separately for each dimension, e.g. millimeters per pixel in x. (Note: The sampling *interval* is the reciprocal of the sampling *rate*.)
 
-"Resolution" should be considered synonymous with "spatial resolution" unless otherwise specified.
+*Resolution* should be considered synonymous with "spatial resolution" unless otherwise specified.
 
-The terms "spacing", "pixel spacing", and "pixel resolution" are commonly used to refer to "resolution".
+The terms "spacing", "pixel spacing", and "pixel resolution" are commonly used to refer to *resolution*.
 
-### "sample" 
-A digital number representing a measurement of the energy sensed by a particular cell on a sensor at a discrete point in time. Because cells on a sensor correspond to elements of an array and pixels of an image, "sample" is often used interchangeably with "pixel".
+### *sample*
+A digital number representing a measurement of the energy sensed by a particular cell on a sensor at a discrete point in time. Because cells on a sensor correspond to elements of an array and pixels of an image, *sample* is often used interchangeably with *pixel*.
 
-### "voxel" 
+### *voxel*
 A single sample of a three-dimensional image.
 

--- a/Definitions.md
+++ b/Definitions.md
@@ -21,6 +21,8 @@
 1. An n-dimensional collection of discrete *samples* whose domain is a regular discrete (integer) grid.
 2. A node in a *hierarchy* that contains a data structure of the type described in (1). *Array* nodes cannot have child nodes.
 
+Related terms: [*sample*](#sample), [*image*](#image), [*hierarchy*](#hierarchy)
+
 ### *axis*
 The *physical* interpretation of a discrete, numeric, finite dimension. Generally represented with a 1D variable that is strictly monotonic and has the same name as the axis it represents. An axis must have *physical* units.
 
@@ -33,6 +35,8 @@ A set of discrete locations in abstract space. A domain, or any location within 
 ### *downsampling*
 The act of *resampling* an *image* to a lower *resolution*, often by an integer factor.
 
+Related terms: [*resampling*](#resampling), [*resolution*](#resolution), [*interpolation*](#interpolation)
+
 ### *field of view*
 The *physical* extent of the observed space. In microscopy, FOV may be expressed as the diameter of the circular view seen through the eyepiece. In scientific bioimaging, FOV is typically expressed as linear measurements of the horizontal, vertical, and/or diagonal space captured by the digital sensor.   
 
@@ -43,16 +47,24 @@ The *physical* extent of the observed space. In microscopy, FOV may be expressed
 ### *group*
 A node in a *hierarchy* that can have child nodes, and can contain metadata, but cannot contain *array* data.
 
+Related terms: [*hierarchy*](#hierarchy)
+
 ### *hierarchy*
 A collection of *groups* and *arrays*, connected in a tree-like structure.
 
+Related terms: [*group*](#group), [*array*](#array)
+
 ### *image*
 A set of numbers intended to be displayed on a screen. Ancillary data structures may be required to display or interpret an *image* (such as a lookup table), but these are not part of the *image* itself. An *image* is often, but not necessarily, acquired by a sensor situated within an optical system. *Images* can be represented in compact forms, for example as a compressed sequence of bytes or as a discrete function over a finite domain, but these are not canonical uses of the word “image”, and the word “image” by itself should refer only to *arrays* and array-like data structures.
+
+Related terms: [*array*](#array), [*sample*](#sample), [*pixel*](#pixel), [*voxel*](#voxel), [*axis*](#axis), [*dimension*](#dimension)
 
 ### *interpolation*
 A process that, given an *image*, produces new *samples* at points in the domain not on the discrete image grid.
 
 The most common methods for *interpolation* are "nearest-neighbor", "bi-/tri-/n-linear", "cubic", "windowed sinc".
+
+Related terms: [*resampling*](#resampling), [*downsampling*](#downsampling)
 
 ### *origin*
 1. Of an *array*: the point in the discrete domain with the minimum index (usually zero) for all dimensions.
@@ -84,7 +96,7 @@ A single *sample* of a two-dimensional *image*.
 
 Often used interchangeably with *sample*.
 
-Related terms: *sample*, *voxel*
+Related terms: [*sample*](#sample), [*voxel*](#voxel)
 
 ### *resampling*
 A process that generates a new *array* representing an *image* at a new *resolution*. 
@@ -92,7 +104,7 @@ A process that generates a new *array* representing an *image* at a new *resolut
 The new *resolution* is often an integer multiple of the original image *resolution*, but need not be. *Resampling* methods often
 consist of *filtering* and *interpolation* steps.
 
-Related terms: *downsampling*, *resolution*
+Related terms: [*downsampling*](#downsampling), [*interpolation*](#interpolation), [*resolution*](#resolution)
 
 ### *resolution*
 
@@ -107,6 +119,9 @@ The terms "spacing", "pixel spacing", and "pixel resolution" are commonly used t
 ### *sample*
 A digital number representing a measurement of the energy sensed by a particular cell on a sensor at a discrete point in time. Because cells on a sensor correspond to elements of an *array* and *pixels* of an *image*, *sample* is often used interchangeably with *pixel*.
 
+Related terms: [*pixel*](#pixel), [*voxel*](#voxel), [*image*](#image), [*array*](#array)
+
 ### *voxel*
 A single *sample* of a three-dimensional *image*.
 
+Related terms: [*sample*](#sample), [*pixel*](#pixel)

--- a/Definitions.md
+++ b/Definitions.md
@@ -1,27 +1,55 @@
 # Definitions
 
-- [*array*](#array)
-- [*downsampling*](#downsampling)
-- [*field of view*](#field-of-view)
-- [*filtering*](#filtering)
-- [*group*](#group)
-- [*hierarchy*](#hierarchy)
-- [*image*](#image)
-- [*interpolation*](#interpolation)
-- [*origin*](#origin)
-- [*physical*](#physical)
-- [*pixel*](#pixel)
-- [*resampling*](#resampling)
-- [*resolution*](#resolution)
-- [*sample*](#sample)
-- [*voxel*](#voxel)
+- Basic definitions
+    - [*array*](#array)
+    - [*image*](#image)
+    - [*pixel*](#pixel)
+    - [*sample*](#sample)
+    - [*voxel*](#voxel)
+- Other definitions
+    - [*downsampling*](#downsampling)
+    - [*field of view*](#field-of-view)
+    - [*filtering*](#filtering)
+    - [*group*](#group)
+    - [*hierarchy*](#hierarchy)
+    - [*interpolation*](#interpolation)
+    - [*origin*](#origin)
+    - [*physical*](#physical)
+    - [*resampling*](#resampling)
+    - [*resolution*](#resolution)
 
+
+## Basic definitions
 
 ### *array*
 1. An n-dimensional collection of discrete *samples* whose domain is a regular discrete (integer) grid.
 2. A node in a *hierarchy* that contains a data structure of the type described in (1). *Array* nodes cannot have child nodes.
 
 Related terms: [*sample*](#sample), [*image*](#image), [*hierarchy*](#hierarchy)
+
+### *image*
+A set of numbers intended to be displayed on a screen. Ancillary data structures may be required to display or interpret an *image* (such as a lookup table), but these are not part of the *image* itself. An *image* is often, but not necessarily, acquired by a sensor situated within an optical system. *Images* can be represented in compact forms, for example as a compressed sequence of bytes or as a discrete function over a finite domain, but these are not canonical uses of the word “image”, and the word “image” by itself should refer only to *arrays* and array-like data structures.
+
+Related terms: [*array*](#array), [*sample*](#sample), [*pixel*](#pixel), [*voxel*](#voxel), [*axis*](#axis), [*dimension*](#dimension)
+
+### *pixel*
+A single *sample* of a two-dimensional *image*.
+
+Often used interchangeably with *sample*.
+
+Related terms: [*sample*](#sample), [*voxel*](#voxel)
+
+### *sample*
+A digital number representing a measurement of the energy sensed by a particular cell on a sensor at a discrete point in time. Because cells on a sensor correspond to elements of an *array* and *pixels* of an *image*, *sample* is often used interchangeably with *pixel*.
+
+Related terms: [*pixel*](#pixel), [*voxel*](#voxel), [*image*](#image), [*array*](#array)
+
+### *voxel*
+A single *sample* of a three-dimensional *image*.
+
+Related terms: [*sample*](#sample), [*pixel*](#pixel)
+
+## Other definitions
 
 ### *axis*
 The *physical* interpretation of a discrete, numeric, finite dimension. Generally represented with a 1D variable that is strictly monotonic and has the same name as the axis it represents. An axis must have *physical* units.
@@ -53,11 +81,6 @@ Related terms: [*hierarchy*](#hierarchy)
 A collection of *groups* and *arrays*, connected in a tree-like structure.
 
 Related terms: [*group*](#group), [*array*](#array)
-
-### *image*
-A set of numbers intended to be displayed on a screen. Ancillary data structures may be required to display or interpret an *image* (such as a lookup table), but these are not part of the *image* itself. An *image* is often, but not necessarily, acquired by a sensor situated within an optical system. *Images* can be represented in compact forms, for example as a compressed sequence of bytes or as a discrete function over a finite domain, but these are not canonical uses of the word “image”, and the word “image” by itself should refer only to *arrays* and array-like data structures.
-
-Related terms: [*array*](#array), [*sample*](#sample), [*pixel*](#pixel), [*voxel*](#voxel), [*axis*](#axis), [*dimension*](#dimension)
 
 ### *interpolation*
 A process that, given an *image*, produces new *samples* at points in the domain not on the discrete image grid.
@@ -91,13 +114,6 @@ Non-examples:
     * "the area of segment $B$ is $85$ pixels"
     * "mitosis begins at frame $51$"
 
-### *pixel*
-A single *sample* of a two-dimensional *image*.
-
-Often used interchangeably with *sample*.
-
-Related terms: [*sample*](#sample), [*voxel*](#voxel)
-
 ### *resampling*
 A process that generates a new *array* representing an *image* at a new *resolution*. 
 
@@ -115,13 +131,3 @@ Related terms: [*downsampling*](#downsampling), [*interpolation*](#interpolation
 *Resolution* should be considered synonymous with "spatial resolution" unless otherwise specified.
 
 The terms "spacing", "pixel spacing", and "pixel resolution" are commonly used to refer to *resolution*.
-
-### *sample*
-A digital number representing a measurement of the energy sensed by a particular cell on a sensor at a discrete point in time. Because cells on a sensor correspond to elements of an *array* and *pixels* of an *image*, *sample* is often used interchangeably with *pixel*.
-
-Related terms: [*pixel*](#pixel), [*voxel*](#voxel), [*image*](#image), [*array*](#array)
-
-### *voxel*
-A single *sample* of a three-dimensional *image*.
-
-Related terms: [*sample*](#sample), [*pixel*](#pixel)

--- a/Definitions.md
+++ b/Definitions.md
@@ -61,6 +61,7 @@ A set of discrete locations in abstract space. A domain, or any location within 
 
 ### *downsampling*
 The act of *resampling* an *image* to a lower *resolution*, often by an integer factor.
+Sometimes this can require *interpolation*.
 
 Related terms: [*resampling*](#resampling), [*resolution*](#resolution), [*interpolation*](#interpolation)
 
@@ -96,7 +97,7 @@ Related terms: [*resampling*](#resampling), [*downsampling*](#downsampling)
 The term "offset" is sometimes used to refer to the *origin*.
 
 ### *physical*
-Relating to quantities or measurements of the physical world.
+Relating to quantities or measurements of the real world.
 
 Examples:
 * *sample* intensities measured by a *physical* sensor
@@ -117,7 +118,7 @@ Non-examples:
 ### *resampling*
 A process that generates a new *array* representing an *image* at a new *resolution*. 
 
-The new *resolution* is often an integer multiple of the original image *resolution*, but need not be. *Resampling* methods often
+The new *resolution* is often an integer multiple or fraction of the original image *resolution*, but need not be. *Resampling* methods often
 consist of *filtering* and *interpolation* steps.
 
 Related terms: [*downsampling*](#downsampling), [*interpolation*](#interpolation), [*resolution*](#resolution)

--- a/Definitions.md
+++ b/Definitions.md
@@ -22,8 +22,7 @@
 ## Basic definitions
 
 ### *array*
-1. An n-dimensional collection of discrete *samples* whose domain is a regular discrete (integer) grid.
-2. A node in a *hierarchy* that contains a data structure of the type described in (1). *Array* nodes cannot have child nodes.
+An n-dimensional collection of discrete *samples* whose domain is a regular discrete (integer) grid.
 
 Related terms: [*sample*](#sample), [*image*](#image), [*hierarchy*](#hierarchy)
 
@@ -73,12 +72,13 @@ The *physical* extent of the observed space. In microscopy, FOV may be expressed
 2. Any operation that modifies the intensity values of an *image*.
 
 ### *group*
-A node in a *hierarchy* that can have child nodes, and can contain metadata, but cannot contain *array* data.
-
-Related terms: [*hierarchy*](#hierarchy)
+See [*hierarchy*](#hierarchy).
 
 ### *hierarchy*
-A collection of *groups* and *arrays*, connected in a tree-like structure.
+A collection of nodes, connected in a tree-like structure.
+A node can be either:
+1. A group, i.e., a node that can have child nodes, and can contain metadata, but cannot contain *array* data.
+2. An *array*. *Array* nodes cannot have child nodes.
 
 Related terms: [*group*](#group), [*array*](#array)
 

--- a/Definitions.md
+++ b/Definitions.md
@@ -18,45 +18,45 @@
 
 
 ### *array*
-1. An n-dimensional collection of discrete samples whose domain is a regular discrete (integer) grid.
-2. A node in a hierarchy that contains a data structure of the type described in (1). Array nodes cannot have child nodes.
+1. An n-dimensional collection of discrete *samples* whose domain is a regular discrete (integer) grid.
+2. A node in a *hierarchy* that contains a data structure of the type described in (1). *Array* nodes cannot have child nodes.
 
 ### *axis*
-The physical interpretation of a discrete, numeric, finite dimension. Generally represented with a 1D variable that is strictly monotonic and has the same name as the axis it represents. An axis must have physical units.
+The *physical* interpretation of a discrete, numeric, finite dimension. Generally represented with a 1D variable that is strictly monotonic and has the same name as the axis it represents. An axis must have *physical* units.
 
 ### *dimension*
 An independent extent of a domain. A domain has N dimensions where N is the minimum number of coordinates needed to identify any particular point within the domain. The length of a discrete, numeric, finite dimension establishes the number of indexable locations along that dimension.
 
 ### *domain*
-A set of discrete locations in abstract space. A domain, or any location within a domain, may be described by multiple variables, but any given variable has only one domain. A domain has zero or more dimensions. The component dimensions of a domain need not be numeric, but when they are, the domain may be thought of as situated in a coordinate space. If a domain's dimensions are all axes, then that domain is situated in a physical space.
+A set of discrete locations in abstract space. A domain, or any location within a domain, may be described by multiple variables, but any given variable has only one domain. A domain has zero or more dimensions. The component dimensions of a domain need not be numeric, but when they are, the domain may be thought of as situated in a coordinate space. If a domain's dimensions are all axes, then that domain is situated in a *physical* space.
 
 ### *downsampling*
-The act of resampling an image to a lower resolution, often by an integer factor.
+The act of *resampling* an *image* to a lower *resolution*, often by an integer factor.
 
 ### *field of view*
-The physical extent of the observed space. In microscopy, FOV may be expressed as the diameter of the circular view seen through the eyepiece. In scientific bioimaging, FOV is typically expressed as linear measurements of the horizontal, vertical, and/or diagonal space captured by the digital sensor.   
+The *physical* extent of the observed space. In microscopy, FOV may be expressed as the diameter of the circular view seen through the eyepiece. In scientific bioimaging, FOV is typically expressed as linear measurements of the horizontal, vertical, and/or diagonal space captured by the digital sensor.   
 
 ### *filtering*
-1. Usually referes to a convolution operation (a local, linear operation on the intensity values of an image).
-2. Any operation that modifies the intensity values of an image.
+1. Usually referes to a convolution operation (a local, linear operation on the intensity values of an *image*).
+2. Any operation that modifies the intensity values of an *image*.
 
 ### *group*
-A node in a hierarchy that can have child nodes, and can contain metadata, but cannot contain array data.
+A node in a *hierarchy* that can have child nodes, and can contain metadata, but cannot contain *array* data.
 
 ### *hierarchy*
-A collection of groups and arrays, connected in a tree-like structure.
+A collection of *groups* and *arrays*, connected in a tree-like structure.
 
 ### *image*
-A set of numbers intended to be displayed on a screen. Ancillary data structures may be required to display or interpret an image (such as a lookup table), but these are not part of the image itself. An image is often, but not necessarily, acquired by a sensor situated within an optical system. Images can be represented in compact forms, for example as a compressed sequence of bytes or as a discrete function over a finite domain, but these are not canonical uses of the word “image”, and the word “image” by itself should refer only to arrays and array-like data structures.
+A set of numbers intended to be displayed on a screen. Ancillary data structures may be required to display or interpret an *image* (such as a lookup table), but these are not part of the *image* itself. An *image* is often, but not necessarily, acquired by a sensor situated within an optical system. *Images* can be represented in compact forms, for example as a compressed sequence of bytes or as a discrete function over a finite domain, but these are not canonical uses of the word “image”, and the word “image” by itself should refer only to *arrays* and array-like data structures.
 
 ### *interpolation*
-A process that, given an image, produces new samples at points in the domain not on the discrete image grid.
+A process that, given an *image*, produces new *samples* at points in the domain not on the discrete image grid.
 
-The most common methods for interpolation are "nearest-neighbor", "bi-/tri-/n-linear", "cubic", "windowed sinc".
+The most common methods for *interpolation* are "nearest-neighbor", "bi-/tri-/n-linear", "cubic", "windowed sinc".
 
 ### *origin*
-1. Of an array: the point in the discrete domain with the minimum index (usually zero) for all dimensions.
-2. Of an image: the point in the physical domain corresponding to the array origin.
+1. Of an *array*: the point in the discrete domain with the minimum index (usually zero) for all dimensions.
+2. Of an *image*: the point in the *physical* domain corresponding to the *array* *origin*.
 
 The term "offset" is sometimes used to refer to the *origin*.
 
@@ -64,49 +64,49 @@ The term "offset" is sometimes used to refer to the *origin*.
 Relating to quantities or measurements of the physical world.
 
 Examples:
-* sample intensities measured by a physical sensor
+* *sample* intensities measured by a *physical* sensor
     * photon count
     * [Hounsfield unit](https://en.wikipedia.org/wiki/Hounsfield_scale)
-* distances / areas / volumes / times measured in images in physical units (um, mm, seconds)
+* distances / areas / volumes / times measured in *images* in *physical* units (um, mm, seconds)
     * "the area of segment A is 12 mm^2"
     * "mitosis begins at time = 3.2s"
 
 Non-examples:
-* sample intensities not derived from sensors
+* *sample* intensities not derived from sensors
     * segmentation id
     * the output of a deep neural network model
-* distances / areas / volumes / times described by sample / array indexes
+* distances / areas / volumes / times described by *sample* / *array* indexes
     * "the area of segment B is 85 pixels"
     * "mitosis begins at frame 51"
 
 ### *pixel*
-A single sample of a two-dimensional image.
+A single *sample* of a two-dimensional *image*.
 
 Often used interchangeably with *sample*.
 
 Related terms: *sample*, *voxel*
 
 ### *resampling*
-A process that generates a new array representing an image at a new resolution. 
+A process that generates a new *array* representing an *image* at a new *resolution*. 
 
-The new resolution is often an integer multiple of the original image resolution, but need not be. Resampling methods often
-consist of filtering and interpolation steps.
+The new *resolution* is often an integer multiple of the original image *resolution*, but need not be. *Resampling* methods often
+consist of *filtering* and *interpolation* steps.
 
 Related terms: *downsampling*, *resolution*
 
 ### *resolution*
 
-1. The level of detail in an image. A high resolution image will have more samples than a low resolution image for the same field of view. 
-2. The total number of samples in each dimension of an image. For example, a 2-dimensional image with 1500 pixels along the x dimension and 1000 pixels along the y dimension could be said to have a resolution of 1500 x 1000 (the colloquial convention is to express the dimensions in x, y, z order).
-3. The set of physical (usually spatial) sampling intervals for an image. In other words, the distance between samples. Usually expressed separately for each dimension, e.g. millimeters per pixel in x. (Note: The sampling *interval* is the reciprocal of the sampling *rate*.)
+1. The level of detail in an *image*. A high *resolution* *image* will have more *samples* than a low *resolution* *image* for the same *field of view*. 
+2. The total number of *samples* in each dimension of an *image*. For example, a 2-dimensional *image* with 1500 *pixels* along the x dimension and 1000 *pixels* along the y dimension could be said to have a *resolution* of 1500 x 1000 (the colloquial convention is to express the dimensions in x, y, z order).
+3. The set of *physical* (usually spatial) sampling intervals for an *image*. In other words, the distance between *samples*. Usually expressed separately for each dimension, e.g. millimeters per *pixel* in x. (Note: The sampling *interval* is the reciprocal of the sampling *rate*.)
 
 *Resolution* should be considered synonymous with "spatial resolution" unless otherwise specified.
 
 The terms "spacing", "pixel spacing", and "pixel resolution" are commonly used to refer to *resolution*.
 
 ### *sample*
-A digital number representing a measurement of the energy sensed by a particular cell on a sensor at a discrete point in time. Because cells on a sensor correspond to elements of an array and pixels of an image, *sample* is often used interchangeably with *pixel*.
+A digital number representing a measurement of the energy sensed by a particular cell on a sensor at a discrete point in time. Because cells on a sensor correspond to elements of an *array* and *pixels* of an *image*, *sample* is often used interchangeably with *pixel*.
 
 ### *voxel*
-A single sample of a three-dimensional image.
+A single *sample* of a three-dimensional *image*.
 


### PR DESCRIPTION
After a very constructive discussion with @bogovicj, I re-structured the collections of fundamental definitions. In particular, I:
- grouped definitions into basic and derived definitions;
- changed highlighting from quotes to italics;
- added a "related terms" line for many definitions and cross-linked relevant terms;
- did some minor clean-up and improvements.